### PR TITLE
Mysensors component

### DIFF
--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -16,7 +16,8 @@ import homeassistant.external.pymysensors.mysensors.mysensors as mysensors
 import homeassistant.external.pymysensors.mysensors.const as const
 from homeassistant.helpers.entity import Entity
 
-from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP, TEMP_CELCIUS)
 
 CONF_PORT = "port"
 
@@ -50,6 +51,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     gateway = mysensors.SerialGateway(port, sensor_update)
     gateway.start()
+
+    # Just assume celcius means that the user wants metric for now.
+    # It may make more sense to make this a global config option in the future.
+    gateway.metric = (hass.config.temperature_unit == TEMP_CELCIUS)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
                          lambda event: gateway.stop())

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -37,9 +37,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             devices[nid] = MySensorsNode(sensor.sketch_name)
             add_devices([devices[nid]])
 
-        devices[nid].battery_level = sensor.battery_level
+        node = devices[nid]
+        node.battery_level = sensor.battery_level
         for child_id, child in sensor.children.items():
-            devices[nid].update_child(child_id, child)
+            node.update_child(child_id, child)
+        node.update_ha_state()
 
     port = config.get(CONF_PORT)
     if port is None:
@@ -59,6 +61,11 @@ class MySensorsNode(Entity):
         self._name = name
         self.battery_level = 0
         self.children = {}
+
+    @property
+    def should_poll(self):
+        """ MySensor gateway pushes its state to HA.  """
+        return False
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/mysensors.py
+++ b/homeassistant/components/sensor/mysensors.py
@@ -16,7 +16,7 @@ import homeassistant.external.pymysensors.mysensors.mysensors as mysensors
 import homeassistant.external.pymysensors.mysensors.const as const
 from homeassistant.helpers.entity import Entity
 
-from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.const import (ATTR_BATTERY_LEVEL, EVENT_HOMEASSISTANT_STOP)
 
 CONF_PORT = "port"
 
@@ -48,6 +48,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     gateway = mysensors.SerialGateway(port, sensor_update)
     gateway.start()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,
+                         lambda event: gateway.stop())
 
 
 class MySensorsNode(Entity):


### PR DESCRIPTION
Updates to use the latest changes from pymysensors.

One of the features that's missing from this is persisting the node configurations.  As best I can tell, MySensors nodes will send a presentation message once when setting up the node and then never again as long as the gateway remains responsive.  This means that if you restart HA while the sensor is asleep, it will disappear from the HA states and you'll have to power-cycle the sensor to get it to show up again.  In my original branch, I persisted the states to a separate YAML file, but I'm not sure if that's the best solution.

Anyways, test it out and let me know what you think!  Then we can work on getting it merged into HA.
